### PR TITLE
feat: add arg support for setup scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 - Use conventional commit messages such as `feat:`, `fix:` and `docs:`.
 - Scripts:
-  - `setup-act.sh` expects `ACT_VERSION` to install Docker and the `act` CLI.
+  - `setup-act.sh` installs Docker and `act`. Pass the desired act version as the first argument.
   - `setup-bun.sh` installs Bun if missing.
-  - `setup-dotnet.sh` expects `DOTNET_SDK_VERSION` and installs the .NET SDK.
+  - `setup-dotnet.sh` installs the .NET SDK. Pass the SDK version as the first argument.
 - Keep this file and the README up to date when scripts or usage change.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Installs Docker (if needed) and the [`act`](https://github.com/nektos/act) binar
 
 Usage:
 ```bash
-# specify the act version to install
-ACT_VERSION=0.2.57 ./setup-act.sh
+./setup-act.sh 0.2.57
 ```
 
 ### `setup-bun.sh`
@@ -26,7 +25,7 @@ Installs the .NET SDK via the Microsoft package repositories.
 
 Usage:
 ```bash
-DOTNET_SDK_VERSION=8.0 ./setup-dotnet.sh
+./setup-dotnet.sh 8.0
 ```
 
 ## Contributing

--- a/setup-act.sh
+++ b/setup-act.sh
@@ -1,6 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  echo "Usage: $0 ACT_VERSION" >&2
+  echo "Installs Docker and the act CLI using the specified version." >&2
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if [ -z "${1:-}" ]; then
+  usage
+  exit 1
+fi
+
+ACT_VERSION=$1
+
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 case "$ARCH" in

--- a/setup-dotnet.sh
+++ b/setup-dotnet.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if ! command -v dotnet &>/dev/null; then
-  echo "Installing Bun…"
-  curl -fsSL https://bun.sh/install | bash
-  export PATH="$HOME/.bun/bin:$PATH"
+usage() {
+  echo "Usage: $0 DOTNET_SDK_VERSION" >&2
+  echo "Installs the specified version of the .NET SDK." >&2
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
 fi
+
+if [ -z "${1:-}" ]; then
+  usage
+  exit 1
+fi
+
+DOTNET_SDK_VERSION=$1
 
 wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb \
      -O packages-microsoft-prod.deb


### PR DESCRIPTION
## Summary
- use CLI arguments for `setup-act.sh`
- use CLI arguments for `setup-dotnet.sh`
- document argument usage in README
- keep AGENTS.md in sync

## Testing
- `shellcheck setup-act.sh setup-bun.sh setup-dotnet.sh` *(fails: command not found)*
- `bash -n setup-act.sh setup-bun.sh setup-dotnet.sh`

------
https://chatgpt.com/codex/tasks/task_e_686bb7bf245c83248120b13264737a19